### PR TITLE
CLN: remove wrong maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @conda-forge/event-model @kperez @mrakitin
+* @conda-forge/event-model @mrakitin

--- a/README.md
+++ b/README.md
@@ -227,6 +227,5 @@ Feedstock Maintainers
 =====================
 
 * [@conda-forge/event-model](https://github.com/conda-forge/event-model/)
-* [@kperez](https://github.com/kperez/)
 * [@mrakitin](https://github.com/mrakitin/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,6 +40,5 @@ about:
 
 extra:
   recipe-maintainers:
-    - kperez
     - mrakitin
     - conda-forge/event-model

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 1e66467a0b7c15f42e2d616abeb2d80aa81d9e0ccca50991dc79bdb99f39d8c1
 
 build:
-  number: 1
+  number: 2
   entry_points:
     - pyshortcut = pyshortcuts:shortcut_cli
   script: {{ PYTHON }} -m pip install . -vv --no-deps


### PR DESCRIPTION
https://github.com/conda-forge/pyshortcuts-feedstock/commit/7a1510c66e49e16a5c406305017299df52a260b9#commitcomment-60215986 mistakenly added @kperez to the list of maintainers. Sorry about the spelling issue, it was intended to be @kbeeperez. Cleaning up here.
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
